### PR TITLE
Add snowstorm config helper

### DIFF
--- a/src/main/java/com/Gabou/sereneseasonsplus/config/SereneExtendedConfig.java
+++ b/src/main/java/com/Gabou/sereneseasonsplus/config/SereneExtendedConfig.java
@@ -12,6 +12,8 @@ public class SereneExtendedConfig {
     public static final ForgeConfigSpec.DoubleValue CUSTOM_DAY_LENGTH;
     public static final ForgeConfigSpec.DoubleValue CUSTOM_NIGHT_LENGTH;
     public static final ForgeConfigSpec.BooleanValue CUSTOM_CYCLE_LENGTH;
+    public static final ForgeConfigSpec.BooleanValue SNOWSTORM_ENABLED;
+    public static final ForgeConfigSpec.IntValue SNOWSTORM_INTENSITY;
 
     public static final int MIN_CORES_FOR_ASYNC = 6;
 
@@ -29,6 +31,14 @@ public class SereneExtendedConfig {
         TICK_SNOW_REPLACER = builder
                 .comment("Tick interval for snow replacer in ticks. Default is 20 (1 second).")
                 .defineInRange("tickSnowReplacer", 100, 1, Integer.MAX_VALUE);
+        builder.pop();
+        builder.push("snowstorm");
+        SNOWSTORM_ENABLED = builder
+                .comment("Enable snowstorm mode which increases snow pilling intensity.")
+                .define("enabled", false);
+        SNOWSTORM_INTENSITY = builder
+                .comment("Snowstorm intensity value used by Project Atmosphere.")
+                .defineInRange("intensity", 0, 0, 100);
         builder.pop();
         builder.push("seasonalDaylightCycle");
         ENABLE_SEASONAL_DAYLIGHT_CYCLE = builder

--- a/src/main/java/com/Gabou/sereneseasonsplus/features/SnowPiller.java
+++ b/src/main/java/com/Gabou/sereneseasonsplus/features/SnowPiller.java
@@ -106,9 +106,18 @@ public final class SnowPiller {
      * @param radius search radius
      */
     public static void tickSnow(ServerLevel level, ServerPlayer player, BlockPos center, int radius) {
-        BlockPos target = findTarget(level, player, center, radius);
-        if (target == null) return;
-        placeSnowAt(level, target);
+        int attempts = 1;
+        if (SereneExtendedConfig.SNOWSTORM_ENABLED.get()) {
+            attempts += Math.max(0, SereneExtendedConfig.SNOWSTORM_INTENSITY.get() / 20);
+        }
+
+        for (int i = 0; i < attempts; i++) {
+            BlockPos target = findTarget(level, player, center, radius);
+            if (target == null) {
+                continue;
+            }
+            placeSnowAt(level, target);
+        }
 
     }
 

--- a/src/main/java/com/Gabou/sereneseasonsplus/util/SnowstormHelper.java
+++ b/src/main/java/com/Gabou/sereneseasonsplus/util/SnowstormHelper.java
@@ -1,0 +1,57 @@
+package com.Gabou.sereneseasonsplus.util;
+
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import net.minecraftforge.fml.config.ConfigTracker;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.loading.FMLPaths;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.nio.file.Path;
+
+/**
+ * Utility to toggle the snowstorm state in the Serene Seasons Plus config.
+ *
+ * <p>The Project Atmosphere mod can call these helpers to enable or disable a
+ * snowstorm, which affects how the snow pilling logic behaves.</p>
+ */
+public class SnowstormHelper {
+    private static final Logger LOGGER = LogManager.getLogger("SnowstormHelper");
+
+    private SnowstormHelper() {}
+
+    /**
+     * Enable snowstorm mode and set the desired intensity.
+     *
+     * @param intensity intensity value (0-100)
+     */
+    public static void startSnowstorm(int intensity) {
+        updateSnowstormConfig(true, intensity);
+    }
+
+    /**
+     * Disable snowstorm mode.
+     */
+    public static void stopSnowstorm() {
+        updateSnowstormConfig(false, 0);
+    }
+
+    /**
+     * Writes snowstorm settings to sereneseasonsplus-common.toml and reloads
+     * the config so the changes take effect immediately.
+     */
+    private static void updateSnowstormConfig(boolean enabled, int intensity) {
+        Path configPath = FMLPaths.CONFIGDIR.get().resolve("sereneseasonsplus-common.toml");
+        try (CommentedFileConfig config = CommentedFileConfig.builder(configPath).sync().build()) {
+            config.load();
+            config.set("snowstorm.enabled", enabled);
+            config.set("snowstorm.intensity", intensity);
+            config.save();
+        } catch (Exception e) {
+            LOGGER.warn("Failed to update Serene Seasons Plus config: {}", e.getMessage());
+        }
+
+        ConfigTracker.INSTANCE.loadConfigs(ModConfig.Type.COMMON, FMLPaths.CONFIGDIR.get());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add config entries for snowstorm state and intensity
- add `SnowstormHelper` utility to toggle snowstorm settings
- increase snow pilling attempts when snowstorm mode is enabled

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a32e4a0fc8833194bc8122b3c50f79