### PR TITLE
Track winter snowstorms per chunk

### DIFF
--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
@@ -135,6 +135,8 @@ public class CommonSnowBlockFeature {
                             }
 
                         }
+
+                        HANDLER.onSnowApplied(level, chunkPos, changed);
                     }
                     case MELT_SNOW -> {
                         changed=meltSnowInChunk(level, chunkPos, entry.fullClear());
@@ -577,14 +579,25 @@ public class CommonSnowBlockFeature {
                 tracked.sereneseasonsplus$setLastWinterId(globalWinterId);
                 tracked.sereneseasonsplus$setSnowCount(-1); // back to virgin state
                 tracked.sereneseasonsplus$setHasAppliedInitialSnow(false);
-                tracked.sereneseasonsplus$setShouldApplyInitialSnow(true);
+                tracked.sereneseasonsplus$setShouldApplyInitialSnow(false);
                 tracked.sereneseasonsplus$willReceiveSnow(false);
                 tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(true);
             }
 
-            if (tracked.sereneseasonsplus$shouldApplyInitialSnow()
-                    || !tracked.sereneseasonsplus$hasAppliedInitialSnow()
-                    || tracked.sereneseasonsplus$getSnowCount() <= 0) {
+            boolean pendingSnow = HANDLER.shouldApplySnow(level, chunkPos);
+            boolean hasSnowHistory = pendingSnow
+                    || HANDLER.hasChunkSeenSnow(level, chunkPos)
+                    || tracked.sereneseasonsplus$getSnowCount() > 0;
+
+            if (pendingSnow) {
+                tracked.sereneseasonsplus$setShouldApplyInitialSnow(true);
+                tracked.sereneseasonsplus$willReceiveSnow(true);
+            }
+
+            boolean needsInitialApplication = !tracked.sereneseasonsplus$hasAppliedInitialSnow()
+                    || tracked.sereneseasonsplus$getSnowCount() <= 0;
+
+            if (pendingSnow || (needsInitialApplication && hasSnowHistory)) {
                 enqueueChunkForSnowApply(chunkPos, currentSeason);
                 tracked.sereneseasonsplus$willReceiveSnow(true);
             }
@@ -600,8 +613,10 @@ public class CommonSnowBlockFeature {
         }
 
         // 🌧 rainfall tracking
+        boolean wasRaining = tracked.sereneseasonsplus$wasRaining();
         boolean isRaining = EnvironmentHelper.isRainning(level, chunkPos.getMiddleBlockPosition(65));
-        if (isRaining != tracked.sereneseasonsplus$wasRaining()) {
+        if (isRaining != wasRaining) {
+            HANDLER.onRainChanged(level, chunkPos, isRaining);
             tracked.sereneseasonsplus$incrementWasRaining(isRaining);
             if (!isRaining) {
                 tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(false);
@@ -635,8 +650,17 @@ public class CommonSnowBlockFeature {
                     if (!(access instanceof LevelChunk lc)) continue;
                     ISnowTrackedChunk tracked = (ISnowTrackedChunk) lc;
                     if (bounds != null) {
-                        if ((tracked.sereneseasonsplus$hasAppliedInitialSnow() && tracked.sereneseasonsplus$getSnowCount() > 0) && tracked.sereneseasonsplus$hasReceivedSnowLayerThisStorm()) {
-                            continue; // already processed
+                        boolean pending = HANDLER.shouldApplySnow(level, lc.getPos());
+                        boolean hasSnow = tracked.sereneseasonsplus$getSnowCount() > 0;
+                        if (!pending && !hasSnow) {
+                            continue;
+                        }
+                        if (hasSnow && tracked.sereneseasonsplus$hasReceivedSnowLayerThisStorm()) {
+                            continue; // already processed for this storm
+                        }
+                        if (pending) {
+                            tracked.sereneseasonsplus$setShouldApplyInitialSnow(true);
+                            tracked.sereneseasonsplus$willReceiveSnow(true);
                         }
                         enqueueChunkForSnowApply(lc.getPos(), currentSeason);
                     } else {

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/DefaultSnowEnvironmentHandler.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/DefaultSnowEnvironmentHandler.java
@@ -1,12 +1,38 @@
 package com.Gabou.sereneseasonsplus.features;
 
+import com.Gabou.sereneseasonsplus.storage.ChunkQueue;
+import com.Gabou.sereneseasonsplus.util.EnvironmentHelper;
+import com.Gabou.sereneseasonsplus.util.ISnowTrackedChunk;
 import com.Gabou.sereneseasonsplus.util.SnowUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.LevelChunk;
 import sereneseasons.api.season.Season;
 import sereneseasons.api.season.SeasonHelper;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 public class DefaultSnowEnvironmentHandler implements SnowEnvironmentHandler {
+    private static final class SnowData {
+        int winterId = -1;
+        int stormCount = 0;
+        boolean stormActive = false;
+        final Set<Long> pendingChunks = new HashSet<>();
+        final Set<Long> observedChunks = new HashSet<>();
+    }
+
+    private final Map<ResourceKey<Level>, SnowData> perLevelData = new HashMap<>();
+
+    private SnowData data(ServerLevel level) {
+        return perLevelData.computeIfAbsent(level.dimension(), k -> new SnowData());
+    }
+
     @Override
     public int getBlocksToReplace(ServerLevel level, BlockPos playerPos) {
         Season.SubSeason currentSubSeason = SeasonHelper.getSeasonState(level).getSubSeason();
@@ -16,5 +42,78 @@ public class DefaultSnowEnvironmentHandler implements SnowEnvironmentHandler {
             return CommonSnowBlockFeature.calculateBlocksToReplace(temperature);
         }
         return 0;
+    }
+
+    @Override
+    public void resetWinterState(ServerLevel level, int winterId) {
+        SnowData data = data(level);
+        if (data.winterId == winterId) {
+            return;
+        }
+        data.winterId = winterId;
+        data.stormCount = 0;
+        data.stormActive = false;
+        data.pendingChunks.clear();
+        data.observedChunks.clear();
+    }
+
+    @Override
+    public void onRainChanged(ServerLevel level, ChunkPos chunkPos, boolean isRaining) {
+        SnowData data = data(level);
+        long key = chunkPos.toLong();
+
+        if (isRaining) {
+            boolean snowySeason = EnvironmentHelper.isSnowySeason();
+            if (snowySeason && !data.stormActive) {
+                data.stormActive = true;
+                data.stormCount++;
+            } else if (!snowySeason) {
+                data.stormActive = false;
+            }
+            if (snowySeason && data.pendingChunks.add(key)) {
+                data.observedChunks.add(key);
+            }
+
+            if (snowySeason) {
+                LevelChunk chunk = level.getChunkSource().getChunk(chunkPos.x, chunkPos.z, false);
+                if (chunk instanceof ISnowTrackedChunk tracked) {
+                    tracked.sereneseasonsplus$setShouldApplyInitialSnow(true);
+                    tracked.sereneseasonsplus$willReceiveSnow(true);
+                }
+                ChunkQueue.enqueueScheduled(chunkPos);
+            }
+        } else if (!level.isRaining()) {
+            data.stormActive = false;
+        }
+    }
+
+    @Override
+    public boolean shouldApplySnow(ServerLevel level, ChunkPos chunkPos) {
+        return data(level).pendingChunks.contains(chunkPos.toLong());
+    }
+
+    @Override
+    public void onSnowApplied(ServerLevel level, ChunkPos chunkPos, boolean success) {
+        SnowData data = data(level);
+        long key = chunkPos.toLong();
+        if (success) {
+            data.pendingChunks.remove(key);
+        }
+        data.observedChunks.add(key);
+    }
+
+    @Override
+    public int getSnowStormsThisWinter(ServerLevel level) {
+        return data(level).stormCount;
+    }
+
+    @Override
+    public boolean hasChunkSeenSnow(ServerLevel level, ChunkPos chunkPos) {
+        return data(level).observedChunks.contains(chunkPos.toLong());
+    }
+
+    @Override
+    public void clear(ServerLevel level) {
+        perLevelData.remove(level.dimension());
     }
 }

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/SnowEnvironmentHandler.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/SnowEnvironmentHandler.java
@@ -2,7 +2,53 @@ package com.Gabou.sereneseasonsplus.features;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 
+/**
+ * Loader specific hooks used to align snow placement with the active weather
+ * system.  The default implementation keeps track of the chunks that received
+ * natural snowfall so the common snow logic can avoid blanketing the world the
+ * moment winter begins.
+ */
 public interface SnowEnvironmentHandler {
     int getBlocksToReplace(ServerLevel level, BlockPos playerPos);
+
+    /**
+     * Clears any per-level bookkeeping for the newly detected winter.
+     */
+    void resetWinterState(ServerLevel level, int winterId);
+
+    /**
+     * Called whenever the rain/snow state for a chunk transitions.
+     */
+    void onRainChanged(ServerLevel level, ChunkPos chunkPos, boolean isRaining);
+
+    /**
+     * Returns {@code true} if this chunk should currently receive natural snow
+     * (e.g. because a storm has recently passed over it).
+     */
+    boolean shouldApplySnow(ServerLevel level, ChunkPos chunkPos);
+
+    /**
+     * Records the result of an attempted snow application. Successful
+     * placements clear any pending flags so subsequent storms can retrigger the
+     * chunk.
+     */
+    void onSnowApplied(ServerLevel level, ChunkPos chunkPos, boolean success);
+
+    /**
+     * @return number of storms detected for the active winter on this level.
+     */
+    int getSnowStormsThisWinter(ServerLevel level);
+
+    /**
+     * @return {@code true} if we have observed natural snowfall in this chunk
+     * during the current winter.
+     */
+    boolean hasChunkSeenSnow(ServerLevel level, ChunkPos chunkPos);
+
+    /**
+     * Clears any cached state for the supplied level (typically on shutdown).
+     */
+    void clear(ServerLevel level);
 }

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/ServerLevelMixin.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/ServerLevelMixin.java
@@ -62,8 +62,10 @@ public class ServerLevelMixin {
 
         }
 
+        boolean wasRaining = tracked.sereneseasonsplus$wasRaining();
         boolean isRaining = EnvironmentHelper.isRainning(level, chunk.getPos().getMiddleBlockPosition(65));
-        if (isRaining != tracked.sereneseasonsplus$wasRaining()) {
+        if (isRaining != wasRaining) {
+            CommonSnowBlockFeature.HANDLER.onRainChanged(level, chunk.getPos(), isRaining);
             tracked.sereneseasonsplus$incrementWasRaining(isRaining);
             if (!isRaining) {
                 tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(false);
@@ -82,7 +84,8 @@ public class ServerLevelMixin {
                 tracked.sereneseasonsplus$willReceiveSnow(false);
                 return;
             }
-            if (tracked.sereneseasonsplus$getSnowCount() <= 0
+            boolean shouldSnow = CommonSnowBlockFeature.HANDLER.shouldApplySnow(level, chunk.getPos());
+            if (shouldSnow && tracked.sereneseasonsplus$getSnowCount() <= 0
                     && !tracked.sereneseasonsplus$hasReceivedSnowLayerThisStorm()) {
 
                 ChunkQueue.enqueueApply(chunk.getPos(), currentSeason);

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/util/EnvironmentHelper.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/util/EnvironmentHelper.java
@@ -108,6 +108,7 @@ public class EnvironmentHelper {
     {
         onWorldLoad(level);
         onSeasonChange(level,false);
+        CommonSnowBlockFeature.HANDLER.resetWinterState(level, currentWinterId);
     }
 
 
@@ -124,6 +125,7 @@ public class EnvironmentHelper {
         Season.SubSeason current = getCurrentSeason();
         if (current == Season.SubSeason.EARLY_WINTER && lastSubSeason != Season.SubSeason.EARLY_WINTER) {
             currentWinterId++; // new winter!
+            CommonSnowBlockFeature.HANDLER.resetWinterState(serverLevel, currentWinterId);
         }
         lastSubSeason = current;
 
@@ -134,6 +136,7 @@ public class EnvironmentHelper {
 
     public static void onServerStopping(ServerLevel level) {
         onWorldSave(level);
+        CommonSnowBlockFeature.HANDLER.clear(level);
     }
 
 }


### PR DESCRIPTION
## Summary
- extend the snow environment handler API so loaders can track per-level storm metadata and expose snow coverage
- persist winter snowstorm counts and pending chunk flags in the default handler and reset them when the season changes
- gate snow placement logic on the new handler data so chunks only receive snow after recorded storms

## Testing
- ./gradlew build *(fails: changelog task expects a git remote in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fdf90020833185a8a50de00c3174