### PR TITLE
Refactor snow tracking to rely on tick updates

### DIFF
--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
@@ -129,23 +129,11 @@ public class CommonSnowBlockFeature {
                         case APPLY_SNOW -> {
                             int globalWinterId = EnvironmentHelper.getCurrentWinterId();
                             Season.SubSeason subSeason = EnvironmentHelper.getCurrentSeason();
+                            if (subSeason == null) {
+                                break;
+                            }
                             if (tracked.sereneseasonsplus$getLastWinterId() != globalWinterId) {
                                 tracked.sereneseasonsplus$setLastWinterId(globalWinterId);
-                                tracked.sereneseasonsplus$setSnowCount(-1); // back to virgin state
-                                tracked.sereneseasonsplus$setHasAppliedInitialSnow(false);
-                                tracked.sereneseasonsplus$setShouldApplyInitialSnow(false);
-                                tracked.sereneseasonsplus$willReceiveSnow(false);
-                                tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(true);
-                                continue;
-                            }
-                            // Guard extra piling during active first snowfall
-                            boolean isRainingNow = EnvironmentHelper.isRainning(level, chunkPos.getMiddleBlockPosition(65));
-                            int sc = tracked.sereneseasonsplus$getSnowCount();
-                            boolean allowPile = (sc < 1) || (sc > 1) || (sc == 1 && !isRainingNow);
-                            if (!allowPile) {
-                                enqueueChunkForSnowApplyWithSitting(chunkPos, subSeason, entry.sittingTicks());
-                                tracked.sereneseasonsplus$willReceiveSnow(true);
-                                break;
                             }
 
                             changed = applySnowToChunk(level, chunkPos, subSeason, level.getRandom());
@@ -153,20 +141,7 @@ public class CommonSnowBlockFeature {
                                 chunkTaskTypes.put(chunkPos, ChunkQueue.TaskType.APPLY_SNOW);
                                 chunksToDirty.add(chunkPos);
                                 chunksWithAppliedChanges.add(chunkPos);
-                            } else {
-                                if (tracked.sereneseasonsplus$getSnowCount() <= 0 && entry.sittingTicks() < 20) {
-                                    // virgin chunk → try again later
-                                    tracked.sereneseasonsplus$willReceiveSnow(true);
-                                    enqueueChunkForSnowApplyWithSitting(chunkPos, subSeason, entry.sittingTicks());
-                                } else {
-                                    // already had snow before → mark handled
-                                    tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(true);
-                                    tracked.sereneseasonsplus$willReceiveSnow(false);
-                                    ChunkQueue.enqueueBugged(chunkPos, subSeason);
-                                }
-
                             }
-
                         }
                         case MELT_SNOW -> {
                             changed = meltSnowInChunk(level, chunkPos, entry.fullClear());
@@ -199,58 +174,8 @@ public class CommonSnowBlockFeature {
         }
     }
 
-    public static void handleOnChunkLoad(LevelChunk chunk, ServerLevel level) {
-        counterTime++;
-        ISnowTrackedChunk tracked = (ISnowTrackedChunk) chunk;
-        if (tracked == null) return;
-
-        ChunkPos chunkPos = chunk.getPos();
-        // Instant converge: pile or melt immediately
-        boolean cold = HANDLER.isColdEnoughForSnow(level, chunkPos.getMiddleBlockPosition(level.getMinBuildHeight()));
-        boolean anyChanged = false;
-        if (cold) {
-            anyChanged = pileChunkTowardsGlobal(level, chunk);
-            if (anyChanged) {
-                chunkTaskTypes.put(chunkPos, ChunkQueue.TaskType.APPLY_SNOW);
-                chunksToDirty.add(chunkPos);
-            }
-        } else if (shouldMeltInSeason(level)) {
-            anyChanged = meltEntireColumns(level, chunk);
-            if (anyChanged) {
-                chunkTaskTypes.put(chunkPos, ChunkQueue.TaskType.MELT_SNOW);
-                chunksToDirty.add(chunkPos);
-            }
-        }
-        if (anyChanged) {
-            processQueuedChanges(level, Integer.MAX_VALUE);
-            finalizeChunkBatch(level);
-        }
-
-        // Also let periodic logic update flags
-        var seasonState = SeasonHelper.getSeasonState(level);
-        Season.SubSeason currentSeason = EnvironmentHelper.getCurrentSeason();
-        if (seasonState == null || currentSeason == null) {
-            ChunkQueue.enqueueScheduled(chunkPos);
-            return;
-        }
-        SnowLogic.evaluate(level, currentSeason, seasonState, tracked, chunkPos, true, chunk.getHeight());
-    }
-
-
     public static void enqueueChunkForSnowApply(ChunkPos chunkPos, Season.SubSeason subSeason) {
         ChunkQueue.enqueueApply(chunkPos, subSeason);
-    }
-
-    /**
-     * Enqueue with sitting ticks to avoid busy looping on virgin chunks that have no snow yet.
-     * already incremented by one to avoid 0 sitting ticks.
-     *
-     * @param chunkPos  the chunk position
-     * @param subSeason the sub season
-     * @param sitting   the sitting ticks
-     */
-    public static void enqueueChunkForSnowApplyWithSitting(ChunkPos chunkPos, Season.SubSeason subSeason, int sitting) {
-        ChunkQueue.enqueueApplyWithSitting(chunkPos, subSeason, sitting + 1);
     }
 
     public static void enqueueChunkForSnowMelt(ChunkPos chunkPos, boolean fullClear) {
@@ -656,8 +581,6 @@ public class CommonSnowBlockFeature {
     }
 
 
-    public static int counterTime = 0;
-
     /**
      * Sweep loaded chunks around players once shortly after startup and
      * enqueue any that missed the initial on-load window.
@@ -738,15 +661,12 @@ public class CommonSnowBlockFeature {
         tickCounter = 0;
         snowStormEnabled = snowStorm;
         ChunkQueue.clear();
-        counterTime = 0;
-
     }
 
     public static void onServerStopping() {
         playerPositions.clear();
         tickCounter = 0;
         ChunkQueue.clear();
-        counterTime = 0;
     }
 
     /**
@@ -774,10 +694,6 @@ public class CommonSnowBlockFeature {
                 for (int dz = -view; dz <= view; dz++) {
                     LevelChunk access = source.getChunk(pc.x + dx, pc.z + dz, false);
                     if (access == null) continue;
-                    ISnowTrackedChunk tracked = (ISnowTrackedChunk) access;
-                    tracked.sereneseasonsplus$willReceiveSnow(false);
-                    tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(true);
-
                 }
             }
         }
@@ -1111,21 +1027,9 @@ public class CommonSnowBlockFeature {
             LevelChunk chunk = level.getChunkSource().getChunk(cp.x, cp.z, false);
             if (chunk == null) continue;
             chunk.setUnsaved(true);
-            ISnowTrackedChunk tracked = (ISnowTrackedChunk) chunk;
             ChunkQueue.TaskType type = chunkTaskTypes.get(cp);
             if (type == ChunkQueue.TaskType.APPLY_SNOW) {
-                tracked.sereneseasonsplus$setHasAppliedInitialSnow(true);
-                tracked.sereneseasonsplus$setShouldApplyInitialSnow(false);
-                tracked.sereneseasonsplus$incrementSnowCount();
-                tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(true);
-                tracked.sereneseasonsplus$willReceiveSnow(false);
                 HANDLER.onSnowApplied(level, cp, chunksWithAppliedChanges.contains(cp));
-            } else if (type == ChunkQueue.TaskType.MELT_SNOW) {
-                tracked.sereneseasonsplus$setHasAppliedInitialSnow(false);
-                tracked.sereneseasonsplus$setShouldApplyInitialSnow(false);
-                tracked.sereneseasonsplus$setSnowCount(0);
-                tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(false);
-                tracked.sereneseasonsplus$willReceiveSnow(false);
             }
         }
         chunksToDirty.clear();

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/DefaultSnowEnvironmentHandler.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/DefaultSnowEnvironmentHandler.java
@@ -113,8 +113,6 @@ public class DefaultSnowEnvironmentHandler implements SnowEnvironmentHandler {
             }
 
             if (snowySeason) {
-                trackedChunk.sereneseasonsplus$setShouldApplyInitialSnow(true);
-                trackedChunk.sereneseasonsplus$willReceiveSnow(true);
                 ChunkQueue.enqueueScheduled(chunkPos);
             }
         } else if (!EnvironmentHelper.isRainning(level, chunkPos.getMiddleBlockPosition(65))) {

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/logic/SnowLogic.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/logic/SnowLogic.java
@@ -31,13 +31,13 @@ public final class SnowLogic {
         // --- Case 1: Cold enough => pile snow ---
         if (coldEnough) {
             float globalAvg = CommonSnowBlockFeature.computeGlobalAvg(level);
-            int totalPositions = tracked.sereneseasonsplus$getSnowColumnsCount();
+            int totalPositions = tracked.sereneseasonsplus$getTrackedColumnCount();
             if (totalPositions == 0) {
                 if (globalAvg > 0.5f) {
                     ChunkQueue.enqueueApply(chunkPos, currentSeason);
                 }
             } else {
-                float currentAvg = (float) tracked.sereneseasonsplus$getSnowColumnsTotalLayers() / (float) totalPositions;
+                float currentAvg = (float) tracked.sereneseasonsplus$getTotalSnowLayers() / (float) totalPositions;
                 if (Math.abs(currentAvg - globalAvg) > 1.0f) {
                     ChunkQueue.enqueueApply(chunkPos, currentSeason);
                 }

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/ChunkSerializerSnowMixin.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/ChunkSerializerSnowMixin.java
@@ -12,7 +12,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import sereneseasons.api.season.Season;
 
 @Mixin(ChunkSerializer.class)
 public abstract class ChunkSerializerSnowMixin {
@@ -24,16 +23,6 @@ public abstract class ChunkSerializerSnowMixin {
         CompoundTag root = cir.getReturnValue();
         if (access instanceof ISnowTrackedChunk tracked) {
             CompoundTag tag = new CompoundTag();
-            tag.putInt("SnowCount", tracked.sereneseasonsplus$getSnowCount());
-            tag.putBoolean("HasAppliedInitialSnow", tracked.sereneseasonsplus$hasAppliedInitialSnow());
-            tag.putBoolean("ShouldApplyInitialSnow", tracked.sereneseasonsplus$shouldApplyInitialSnow());
-            tag.putBoolean("WasRaining", tracked.sereneseasonsplus$wasRaining());
-            tag.putBoolean("HasReceivedSnowLayerThisStorm", tracked.sereneseasonsplus$hasReceivedSnowLayerThisStorm());
-            tag.putBoolean("WillReceiveSnow", tracked.sereneseasonsplus$shouldReceiveSnow());
-            if (tracked.sereneseasonsplus$getLastSeason() != null) {
-                tag.putString("LastSeason", tracked.sereneseasonsplus$getLastSeason().name());
-            }
-            // Persist last winter id correctly
             tag.putInt("LastWinterId", tracked.sereneseasonsplus$getLastWinterId());
 
             // Persist snow columns as a list of {Pos: long, Layers: int}
@@ -58,19 +47,8 @@ public abstract class ChunkSerializerSnowMixin {
         if (access instanceof ISnowTrackedChunk tracked) {
             CompoundTag tag = nbt.getCompound(SSP);
             if (!tag.isEmpty()) {
-                tracked.sereneseasonsplus$setSnowCount(tag.getInt("SnowCount"));
-                tracked.sereneseasonsplus$setHasAppliedInitialSnow(tag.getBoolean("HasAppliedInitialSnow"));
-                tracked.sereneseasonsplus$setShouldApplyInitialSnow(tag.getBoolean("ShouldApplyInitialSnow"));
-                tracked.sereneseasonsplus$incrementWasRaining(tag.getBoolean("WasRaining"));
-                tracked.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(tag.getBoolean("HasReceivedSnowLayerThisStorm"));
-                tracked.sereneseasonsplus$willReceiveSnow(tag.getBoolean("WillReceiveSnow"));
                 if (tag.contains("LastWinterId")) {
                     tracked.sereneseasonsplus$setLastWinterId(tag.getInt("LastWinterId"));
-                }
-                if (tag.contains("LastSeason")) {
-                    try {
-                        tracked.sereneseasonsplus$setLastSeason(Season.SubSeason.valueOf(tag.getString("LastSeason")));
-                    } catch (IllegalArgumentException ignored) {}
                 }
                 // Load snow columns
                 tracked.sereneseasonsplus$getSnowColumns().clear();

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/LevelChunkSnowMixin.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/mixin/LevelChunkSnowMixin.java
@@ -10,35 +10,14 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import sereneseasons.api.season.Season;
 
 @Mixin(LevelChunk.class)
 public class LevelChunkSnowMixin implements ISnowTrackedChunk {
     @Unique
-    private Season.SubSeason sereneseasonsplus$lastSeason = null;
-    @Unique
-    private boolean sereneseasonsplus$wasRaining = false;
-    @Unique
-    private boolean sereneseasonsplus$hasReceivedSnowLayerThisStorm = false;
-    @Unique
-    private boolean sereneseasonsplus$shouldApplyInitialSnow = false;
-    @Unique
-    private boolean sereneseasonsplus$hasAppliedInitialSnow = false;
-
+    private int sereneseasonsplus$lastWinterId = -1;
 
     @Unique
-    private boolean sereneseasonsplus$willReceiveSnow = false;
-
-    // NEW: track how many times this chunk has snowed
-    @Unique
-    private int sereneseasonsplus$snowCount = -1;
-
-    @Unique
-    private int sereneseasonsplus$lastWinterId = -1; // -1 means never had a winter
-
-    @Unique
-    private java.util.Map<net.minecraft.core.BlockPos, Integer> sereneseasonsplus$snowColumns = new java.util.HashMap<>();
-
+    private final java.util.Map<net.minecraft.core.BlockPos, Integer> sereneseasonsplus$snowColumns = new java.util.HashMap<>();
 
     @Override
     public int sereneseasonsplus$getLastWinterId() {
@@ -50,93 +29,10 @@ public class LevelChunkSnowMixin implements ISnowTrackedChunk {
         this.sereneseasonsplus$lastWinterId = id;
     }
 
-
-    @Override
-    public Season.SubSeason sereneseasonsplus$getLastSeason() {
-        return sereneseasonsplus$lastSeason;
-    }
-
-    @Override
-    public void sereneseasonsplus$setLastSeason(Season.SubSeason season) {
-        this.sereneseasonsplus$lastSeason = season;
-    }
-
-    @Override
-    public boolean sereneseasonsplus$wasRaining() {
-        return sereneseasonsplus$wasRaining;
-    }
-
-    @Override
-    public void sereneseasonsplus$incrementWasRaining(boolean raining) {
-        this.sereneseasonsplus$wasRaining = raining;
-    }
-
-    @Override
-    public boolean sereneseasonsplus$hasReceivedSnowLayerThisStorm() {
-        return sereneseasonsplus$hasReceivedSnowLayerThisStorm;
-    }
-
-
-    @Override
-    public void sereneseasonsplus$willReceiveSnow(boolean b) {
-        this.sereneseasonsplus$willReceiveSnow = b;
-    }
-
-    @Override
-    public boolean sereneseasonsplus$shouldReceiveSnow() {
-        return this.sereneseasonsplus$willReceiveSnow;
-    }
-
-
-    @Override
-    public void sereneseasonsplus$setHasReceivedSnowLayerThisStorm(boolean value) {
-        this.sereneseasonsplus$hasReceivedSnowLayerThisStorm = value;
-    }
-
-    @Override
-    public boolean sereneseasonsplus$shouldApplyInitialSnow() {
-        return sereneseasonsplus$shouldApplyInitialSnow;
-    }
-
-    @Override
-    public void sereneseasonsplus$setShouldApplyInitialSnow(boolean value) {
-        this.sereneseasonsplus$shouldApplyInitialSnow = value;
-    }
-
-    @Override
-    public boolean sereneseasonsplus$hasAppliedInitialSnow() {
-        return sereneseasonsplus$hasAppliedInitialSnow;
-    }
-
-    @Override
-    public void sereneseasonsplus$setHasAppliedInitialSnow(boolean value) {
-        this.sereneseasonsplus$hasAppliedInitialSnow = value;
-    }
-
-    // --- New accessors for snow count ---
-    @Override
-    public int sereneseasonsplus$getSnowCount() {
-        return sereneseasonsplus$snowCount;
-    }
-
-    @Override
-    public void sereneseasonsplus$incrementSnowCount() {
-        if(sereneseasonsplus$snowCount < 0) {
-            sereneseasonsplus$snowCount = 0;
-        }
-        sereneseasonsplus$snowCount++;
-    }
-
-    @Override
-    public void sereneseasonsplus$setSnowCount(int value) {
-        this.sereneseasonsplus$snowCount = value;
-    }
-
     @Override
     public java.util.Map<net.minecraft.core.BlockPos, Integer> sereneseasonsplus$getSnowColumns() {
         return sereneseasonsplus$snowColumns;
     }
-
 
     @Inject(
             method = "<init>(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/level/chunk/ProtoChunk;Lnet/minecraft/world/level/chunk/LevelChunk$PostLoadProcessor;)V",
@@ -146,21 +42,12 @@ public class LevelChunkSnowMixin implements ISnowTrackedChunk {
                           ProtoChunk proto,
                           @Nullable LevelChunk.PostLoadProcessor post,
                           CallbackInfo ci) {
-        if ((Object)this instanceof ISnowTrackedChunk target && proto instanceof ISnowTrackedChunk src) {
-            target.sereneseasonsplus$setSnowCount(src.sereneseasonsplus$getSnowCount());
-            target.sereneseasonsplus$setHasAppliedInitialSnow(src.sereneseasonsplus$hasAppliedInitialSnow());
-            target.sereneseasonsplus$setShouldApplyInitialSnow(src.sereneseasonsplus$shouldApplyInitialSnow());
-            target.sereneseasonsplus$incrementWasRaining(src.sereneseasonsplus$wasRaining());
-            target.sereneseasonsplus$setHasReceivedSnowLayerThisStorm(src.sereneseasonsplus$hasReceivedSnowLayerThisStorm());
-            if (src.sereneseasonsplus$getLastSeason() != null) {
-                target.sereneseasonsplus$setLastSeason(src.sereneseasonsplus$getLastSeason());
-            }
-            // Copy snow columns map
+        if ((Object) this instanceof ISnowTrackedChunk target && proto instanceof ISnowTrackedChunk src) {
+            target.sereneseasonsplus$setLastWinterId(src.sereneseasonsplus$getLastWinterId());
             this.sereneseasonsplus$snowColumns.clear();
             this.sereneseasonsplus$snowColumns.putAll(src.sereneseasonsplus$getSnowColumns());
         }
     }
-
 }
 
 

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/storage/ChunkQueue.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/storage/ChunkQueue.java
@@ -34,15 +34,6 @@ public final class ChunkQueue {
         TASKS_NEXT_TICK.clear();
     }
 
-    public static void enqueueApplyWithSitting(ChunkPos chunkPos, Season.SubSeason subSeason, int sittingTicks) {
-        EntryKey key = new EntryKey(ChunkPos.asLong(chunkPos.x, chunkPos.z), TaskType.APPLY_SNOW, false);
-        if (SCHEDULED.add(key)) {
-            TASKS_NEXT_TICK.add(new Entry(chunkPos, TaskType.APPLY_SNOW, subSeason, false,sittingTicks));
-        }
-    }
-
-
-
     public static void enqueueScheduled(ChunkPos chunkPos) {
         EntryKey key = new EntryKey(ChunkPos.asLong(chunkPos.x, chunkPos.z), TaskType.APPLY_SNOW, true);
         if (SCHEDULED.add(key)) {
@@ -131,10 +122,7 @@ public final class ChunkQueue {
         SCHEDULED_TASKS.clear();
     }
 
-    public record Entry(ChunkPos pos, TaskType type, Season.SubSeason subSeason, boolean fullClear,int sittingTicks) {
-        public Entry(ChunkPos pos, TaskType type, Season.SubSeason subSeason, boolean fullClear) {
-            this(pos, type, subSeason, fullClear,0);
-        }
+    public record Entry(ChunkPos pos, TaskType type, Season.SubSeason subSeason, boolean fullClear) {
     }
 
     public enum TaskType {

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/util/DefaultRainHandler.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/util/DefaultRainHandler.java
@@ -25,10 +25,18 @@ public class DefaultRainHandler implements IRainHandler {
         CacheEntry e = cache.computeIfAbsent(level, k -> new CacheEntry());
         int tick = com.Gabou.sereneseasonsplus.features.CommonSnowBlockFeature.getTickCounter();
         if (tick - e.lastTick >= CACHE_INTERVAL_TICKS) {
-            e.lastValue = level.isRaining(); // vanilla: global precipitation
+            e.lastValue = queryPrecipitation(level, pos);
             e.lastTick = tick;
         }
         return e.lastValue;
+    }
+
+    /**
+     * Computes the current precipitation state for the supplied level/position.
+     * Subclasses can override to integrate with other weather systems.
+     */
+    protected boolean queryPrecipitation(ServerLevel level, BlockPos pos) {
+        return level.isRaining();
     }
 }
 

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/util/ISnowTrackedChunk.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/util/ISnowTrackedChunk.java
@@ -1,46 +1,26 @@
 package com.Gabou.sereneseasonsplus.util;
 
-import sereneseasons.api.season.Season;
+import net.minecraft.core.BlockPos;
+
+import java.util.Map;
 
 public interface ISnowTrackedChunk {
-    Season.SubSeason sereneseasonsplus$getLastSeason();
-    void sereneseasonsplus$setLastSeason(Season.SubSeason season);
-
-    boolean sereneseasonsplus$wasRaining();
-    void sereneseasonsplus$incrementWasRaining(boolean raining);
-
-    // Tracks whether this chunk already received its single noisy layer for the current storm
-    boolean sereneseasonsplus$hasReceivedSnowLayerThisStorm();
-    void sereneseasonsplus$setHasReceivedSnowLayerThisStorm(boolean value);
-
-    // Tracks whether the chunk should receive deep-winter initialization snow
-    boolean sereneseasonsplus$shouldApplyInitialSnow();
-    void sereneseasonsplus$setShouldApplyInitialSnow(boolean value);
-
-    // Remembers if deep-winter initialization snow has already been applied
-    boolean sereneseasonsplus$hasAppliedInitialSnow();
-    void sereneseasonsplus$setHasAppliedInitialSnow(boolean value);
-    int sereneseasonsplus$getSnowCount();
-    void sereneseasonsplus$incrementSnowCount();
-
-    void sereneseasonsplus$setSnowCount(int value);
-
-
-    void sereneseasonsplus$willReceiveSnow(boolean b);
-    boolean sereneseasonsplus$shouldReceiveSnow();
     int sereneseasonsplus$getLastWinterId();
     void sereneseasonsplus$setLastWinterId(int id);
 
     // Per-chunk snow columns: maps a block position to its current snow layer count
-    java.util.Map<net.minecraft.core.BlockPos, Integer> sereneseasonsplus$getSnowColumns();
-    default int sereneseasonsplus$getSnowColumnsTotalLayers() {
+    Map<BlockPos, Integer> sereneseasonsplus$getSnowColumns();
+
+    default int sereneseasonsplus$getTotalSnowLayers() {
         int sum = 0;
-        for (int v : sereneseasonsplus$getSnowColumns().values()) sum += v;
+        for (int value : sereneseasonsplus$getSnowColumns().values()) {
+            sum += value;
+        }
         return sum;
     }
-    default int sereneseasonsplus$getSnowColumnsCount() {
+
+    default int sereneseasonsplus$getTrackedColumnCount() {
         return sereneseasonsplus$getSnowColumns().size();
     }
-
 }
 

--- a/fabric/src/main/java/com/Gabou/sereneseasonsplus/SereneSeasonsPlusFabric.java
+++ b/fabric/src/main/java/com/Gabou/sereneseasonsplus/SereneSeasonsPlusFabric.java
@@ -9,14 +9,12 @@ import com.Gabou.sereneseasonsplus.util.FabricAsyncExecutorHandler;
 import com.Gabou.sereneseasonsplus.util.FabricEnvironmentHelper;
 import com.Gabou.sereneseasonsplus.util.SereneService;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.chunk.ChunkAccess;
 
 public class SereneSeasonsPlusFabric extends SereneSeasonPlusCommon implements ModInitializer {
 
@@ -27,7 +25,6 @@ public class SereneSeasonsPlusFabric extends SereneSeasonPlusCommon implements M
         // Server lifecycle hooks
         ServerLifecycleEvents.SERVER_STARTED.register(this::onServerStarting);
         ServerLifecycleEvents.SERVER_STOPPING.register(this::onServerStopping);
-        ServerChunkEvents.CHUNK_LOAD.register(this::onChunkLoad);
         EnvironmentHelper.init(new FabricEnvironmentHelper());
         SeasonChangeEvent.register();
         SereneExtendedConfig.registerReloadListener(this::onConfigReload);
@@ -67,14 +64,5 @@ public class SereneSeasonsPlusFabric extends SereneSeasonPlusCommon implements M
         CommonSnowBlockFeature.handleServerTick(level.getServer(), level);
 
     }
-
-    private void onChunkLoad(ServerLevel level, ChunkAccess chunkAccess) {
-        if (level == null) return;
-        if (!(chunkAccess instanceof net.minecraft.world.level.chunk.LevelChunk chunk)) return;
-        if (level.isClientSide()) return;
-        if (level.dimension() != Level.OVERWORLD) return;
-        CommonSnowBlockFeature.handleOnChunkLoad(chunk,level);
-    }
-
 
 }

--- a/forge/src/main/java/com/Gabou/sereneseasonsplus/SereneSeasonsPlusForge.java
+++ b/forge/src/main/java/com/Gabou/sereneseasonsplus/SereneSeasonsPlusForge.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.GameRules;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -129,20 +128,6 @@ public class SereneSeasonsPlusForge extends SereneSeasonPlusCommon{
     public void onConfigReload(TickEvent.ServerTickEvent event) {
         CommonSnowBlockFeature.onConfigReload(SereneExtendedConfig.TICK_SNOW_REPLACER.get(), SereneExtendedConfig.SNOWSTORM_ENABLED.get());
         SereneService.reloadConfig();
-    }
-
-
-    /**
-     * Queues chunk processing when chunks load (e.g., as players move),
-     * so snow/ice are cleared or accelerated-melted immediately without rejoining.
-     */
-    @SubscribeEvent
-    public void onChunkLoad(ChunkEvent.Load event) {
-        if (!(event.getChunk() instanceof net.minecraft.world.level.chunk.LevelChunk chunk)) return;
-        var level = chunk.getLevel();
-        if (level.isClientSide()) return;
-        if (level.dimension() != Level.OVERWORLD) return;
-        CommonSnowBlockFeature.handleOnChunkLoad(chunk, (ServerLevel) level);
     }
 
 

--- a/forge/src/main/java/com/Gabou/sereneseasonsplus/features/ForgeSnowEnvironmentHandler.java
+++ b/forge/src/main/java/com/Gabou/sereneseasonsplus/features/ForgeSnowEnvironmentHandler.java
@@ -75,8 +75,6 @@ public class ForgeSnowEnvironmentHandler extends DefaultSnowEnvironmentHandler {
                 if (data.pendingChunks.add(key)) {
                     data.observedChunks.add(key);
                 }
-                trackedChunk.sereneseasonsplus$setShouldApplyInitialSnow(true);
-                trackedChunk.sereneseasonsplus$willReceiveSnow(true);
                 ChunkQueue.enqueueScheduled(chunkPos);
             }
         } else {

--- a/forge/src/main/java/com/Gabou/sereneseasonsplus/util/ProjectAtmosphereRainHandler.java
+++ b/forge/src/main/java/com/Gabou/sereneseasonsplus/util/ProjectAtmosphereRainHandler.java
@@ -1,37 +1,25 @@
 package com.Gabou.sereneseasonsplus.util;
 
-import com.Gabou.sereneseasonsplus.SereneSeasonsPlusForge;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Rain handler for Project Atmosphere: use per-position precipitation checks.
  */
-public class ProjectAtmosphereRainHandler implements IRainHandler {
-
-    private static final int CACHE_INTERVAL_TICKS = 100;
-
-    private static final class CacheEntry {
-        int lastTick;
-        boolean lastValue;
-    }
-
-    private final Map<ServerLevel, CacheEntry> cache = new HashMap<>();
-
+public class ProjectAtmosphereRainHandler extends DefaultRainHandler {
 
     @Override
-    public boolean isRainingAt(ServerLevel level, BlockPos pos) {
-        CacheEntry e = cache.computeIfAbsent(level, k -> new CacheEntry());
-        int tick = com.Gabou.sereneseasonsplus.features.CommonSnowBlockFeature.getTickCounter();
-        if (tick - e.lastTick >= CACHE_INTERVAL_TICKS) {
-            e.lastValue = level.isRainingAt(pos); // vanilla: global precipitation
-            e.lastTick = tick;
+    protected boolean queryPrecipitation(ServerLevel level, BlockPos pos) {
+        try {
+            Class<?> api = Class.forName("net.Gabou.projectatmosphere.api.AtmoApi");
+            java.lang.reflect.Method method = api.getMethod("isRainingAt", ServerLevel.class, BlockPos.class);
+            Object result = method.invoke(null, level, pos);
+            if (result instanceof Boolean b) {
+                return b;
+            }
+        } catch (Throwable ignored) {
         }
-        return e.lastValue;
-
+        return level.isRaining();
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify ISnowTrackedChunk and LevelChunk mixin to only persist the winter id and tracked snow columns
- rewrite chunk snow processing to run entirely from tick updates and drop chunk-load hooks on Fabric/Forge
- add overridable precipitation query logic for rain handlers and adjust Project Atmosphere integration

## Testing
- `./gradlew :common:compileJava` *(fails: build script requires git remotes in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaa155144833186249e1ecf63503a