### PR TITLE
Fix snow layering behavior during storms

### DIFF
--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/CommonSnowBlockFeature.java
@@ -309,14 +309,40 @@ public class CommonSnowBlockFeature {
                     break;
                 }
 
-                while (need > 0 && topCursor.getY() < level.getMaxBuildHeight()) {
-                    int toPlace = Math.min(8, need);
-                    if (placeOrQueueLayers(level, topCursor, toPlace, true, true)) {
-                        tracked.sereneseasonsplus$getSnowColumns().put(topCursor.immutable(), toPlace);
+                int remaining = need;
+                BlockPos.MutableBlockPos placePos = new BlockPos.MutableBlockPos(topCursor.getX(), topCursor.getY(), topCursor.getZ());
+                BlockPos.MutableBlockPos belowPos = new BlockPos.MutableBlockPos(topCursor.getX(), topCursor.getY() - 1, topCursor.getZ());
+
+                if (belowPos.getY() >= minY) {
+                    BlockState topState = level.getBlockState(belowPos);
+                    if (topState.is(Blocks.SNOW) || topState.is(Blocks.SNOW_BLOCK)) {
+                        int currentLayers = topState.is(Blocks.SNOW_BLOCK)
+                                ? 8
+                                : topState.getValue(BlockStateProperties.LAYERS);
+                        int freeSpace = 8 - currentLayers;
+                        if (freeSpace > 0 && remaining > 0) {
+                            int add = Math.min(freeSpace, remaining);
+                            int targetLayers = currentLayers + add;
+                            if (placeOrQueueLayers(level, belowPos, targetLayers, true, true)) {
+                                tracked.sereneseasonsplus$getSnowColumns().put(belowPos.immutable(), targetLayers);
+                                any = true;
+                            }
+                            remaining -= add;
+                        }
+                        if (remaining <= 0) {
+                            continue;
+                        }
+                    }
+                }
+
+                while (remaining > 0 && placePos.getY() < level.getMaxBuildHeight()) {
+                    int toPlace = Math.min(8, remaining);
+                    if (placeOrQueueLayers(level, placePos, toPlace, true, true)) {
+                        tracked.sereneseasonsplus$getSnowColumns().put(placePos.immutable(), toPlace);
                         any = true;
                     }
-                    need -= toPlace;
-                    topCursor.move(0, 1, 0);
+                    remaining -= toPlace;
+                    placePos.move(0, 1, 0);
                 }
             }
         }
@@ -387,21 +413,41 @@ public class CommonSnowBlockFeature {
 
                 // --- place stacked snow ---
                 BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos(surface.getX(), surface.getY(), surface.getZ());
-                int snowBlocks = totalLayers / 8;
-                int remainder = totalLayers % 8;
+                int remaining = totalLayers;
 
-                for (int i = 0; i < snowBlocks; i++) {
+                BlockState existing = level.getBlockState(cursor);
+                if (existing.is(Blocks.SNOW) || existing.is(Blocks.SNOW_BLOCK)) {
+                    int currentLayers = existing.is(Blocks.SNOW_BLOCK)
+                            ? 8
+                            : existing.getValue(BlockStateProperties.LAYERS);
+                    int freeSpace = 8 - currentLayers;
+                    if (freeSpace > 0 && remaining > 0) {
+                        int add = Math.min(freeSpace, remaining);
+                        int targetLayers = currentLayers + add;
+                        if (placeOrQueueLayers(level, cursor, targetLayers, true, true)) {
+                            tracked.sereneseasonsplus$getSnowColumns().put(cursor.immutable(), targetLayers);
+                            any = true;
+                        }
+                        remaining -= add;
+                    }
+                    if (remaining <= 0) {
+                        continue;
+                    }
+                    cursor.move(0, 1, 0);
+                }
+
+                while (remaining >= 8 && cursor.getY() < level.getMaxBuildHeight()) {
                     if (placeOrQueueLayers(level, cursor, 8, true, true)) {
-                        // Track exactly 8 layers for each full block in the column
                         tracked.sereneseasonsplus$getSnowColumns().put(cursor.immutable(), 8);
                         any = true;
                     }
-                    cursor.move(0, 1, 0); // stack upwards
+                    remaining -= 8;
+                    cursor.move(0, 1, 0);
                 }
 
-                if (remainder > 0) {
-                    if (placeOrQueueLayers(level, cursor, remainder, true, true)) {
-                        tracked.sereneseasonsplus$getSnowColumns().put(cursor.immutable(), remainder);
+                if (remaining > 0 && cursor.getY() < level.getMaxBuildHeight()) {
+                    if (placeOrQueueLayers(level, cursor, remaining, true, true)) {
+                        tracked.sereneseasonsplus$getSnowColumns().put(cursor.immutable(), remaining);
                         any = true;
                     }
                 }

--- a/common/src/main/java/com/Gabou/sereneseasonsplus/features/logic/SnowLogic.java
+++ b/common/src/main/java/com/Gabou/sereneseasonsplus/features/logic/SnowLogic.java
@@ -1,10 +1,10 @@
 package com.Gabou.sereneseasonsplus.features.logic;
 
-import com.Gabou.sereneseasonsplus.SereneSeasonPlusCommon;
 import com.Gabou.sereneseasonsplus.features.CommonSnowBlockFeature;
 import com.Gabou.sereneseasonsplus.storage.ChunkQueue;
 import com.Gabou.sereneseasonsplus.util.EnvironmentHelper;
 import com.Gabou.sereneseasonsplus.util.ISnowTrackedChunk;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import sereneseasons.api.season.ISeasonState;
@@ -30,7 +30,10 @@ public final class SnowLogic {
         }
 
         // --- Check temperature ---
-        boolean coldEnough = CommonSnowBlockFeature.HANDLER.isColdEnoughForSnow(level, chunkPos.getMiddleBlockPosition(maxHeight));
+        BlockPos samplePos = chunkPos.getMiddleBlockPosition(Math.max(level.getMinBuildHeight(), maxHeight));
+        boolean coldEnough = CommonSnowBlockFeature.HANDLER.isColdEnoughForSnow(level, samplePos);
+        boolean snowingNow = EnvironmentHelper.isRainning(level, samplePos);
+        boolean allowApply = snowingNow || isLoadEvent;
 
 
         // --- Case 1: Cold enough => pile snow ---
@@ -43,19 +46,19 @@ public final class SnowLogic {
             if (baseline > 0) {
                 int baselineTotal = baseline * 256; // 16x16 columns per chunk
                 int trackedTotal = tracked.sereneseasonsplus$getTotalSnowLayers();
-                if (trackedTotal < baselineTotal) {
+                if (trackedTotal < baselineTotal && allowApply) {
                     ChunkQueue.enqueueApply(chunkPos, currentSeason);
                     return;
                 }
             }
 
             if (totalPositions == 0) {
-                if (globalAvg > 0.5f) {
+                if (globalAvg > 0.5f && allowApply) {
                     ChunkQueue.enqueueApply(chunkPos, currentSeason);
                 }
             } else {
                 float currentAvg = (float) tracked.sereneseasonsplus$getTotalSnowLayers() / (float) totalPositions;
-                if (Math.abs(currentAvg - globalAvg) > 0.5f) {
+                if (Math.abs(currentAvg - globalAvg) > 0.5f && allowApply) {
                     ChunkQueue.enqueueApply(chunkPos, currentSeason);
                 }
             }


### PR DESCRIPTION
## Summary
- fill partially covered columns before placing new snow blocks so layers increment correctly
- continue stacking snow above eight layers when applying storm patterns
- only queue snow application while precipitation is active to avoid instant respawns when dry

## Testing
- `./gradlew :common:compileJava` *(fails: Gradle changelog task requires a git remote in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df64821f848331b61dae3eca854a2f